### PR TITLE
Fix Vercel GitHub deployment configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "quest-web",
   "version": "1.0.0",
   "description": "Quest Web Application",
+  "type": "module",
   "main": "index.js",
   "scripts": {
     "start": "node src/server/dev-server.js",

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,18 @@
 {
   "version": 2,
+  "buildCommand": "echo 'No build step required for static site'",
+  "outputDirectory": "src/client",
+  "headers": [
+    {
+      "source": "/styles/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    }
+  ],
   "builds": [
     {
       "src": "src/client/**/*",


### PR DESCRIPTION
- Add missing 'type': 'module' to package.json for ES6 modules
- Add buildCommand and outputDirectory to vercel.json
- Add proper headers configuration for static assets
- Ensure GitHub deployment matches direct upload behavior